### PR TITLE
CN-35077: Update annotation patching to work for 1.27

### DIFF
--- a/internal/runners/pvc_autoresizer_test.go
+++ b/internal/runners/pvc_autoresizer_test.go
@@ -704,7 +704,6 @@ var _ = Describe("test resizer", func() {
 								{
 									Kind:       "StatefulSet",
 									Name:       stsName,
-									Controller: &isController,
 									APIVersion: "v1",
 									UID:        "blank",
 								},


### PR DESCRIPTION
For annotation patching, we check for a controller ref in the PVC metadata to find an owner STS. However, for k8s <= 1.27 the `controller` key was not set in the owner ref. To account for this, we now fallback to searching all ownerRefs for the first STS owner.