### PR TITLE
Remove 1.29 e2e tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: "ubuntu-22.04"
     strategy:
       matrix:
-        kubernetes_versions: ["1.32.2", "1.31.6", "1.30.10", "1.29.8"]
+        kubernetes_versions: ["1.32.2", "1.31.6", "1.30.10"]
     env:
       KUBERNETES_VERSION: ${{ matrix.kubernetes_versions }}
     steps:
@@ -33,7 +33,7 @@ jobs:
     runs-on: "ubuntu-22.04"
     strategy:
       matrix:
-        kubernetes_versions: ["1.32.2", "1.31.6", "1.30.10", "1.29.8"]
+        kubernetes_versions: ["1.32.2", "1.31.6", "1.30.10"]
     env:
       KUBERNETES_VERSION: ${{ matrix.kubernetes_versions }}
     steps:
@@ -50,7 +50,7 @@ jobs:
     runs-on: "ubuntu-22.04"
     strategy:
       matrix:
-        kubernetes_versions: ["1.32.2", "1.31.6", "1.30.10", "1.29.8"]
+        kubernetes_versions: ["1.32.2", "1.31.6", "1.30.10"]
     env:
       KUBERNETES_VERSION: ${{ matrix.kubernetes_versions }}
     steps:

--- a/versions.mk
+++ b/versions.mk
@@ -24,3 +24,8 @@ ENVTEST_K8S_VERSION := $(shell echo $(KUBERNETES_VERSION) | cut -d "." -f 1-2)
 # Tools versions which are defined in go.mod
 SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 GINKGO_VERSION := $(shell awk '/github.com\/onsi\/ginkgo\/v2/ {print substr($$2, 2)}' $(SELF_DIR)/go.mod)
+
+ifeq ($(KUBERNETES_VERSION), 1.29.8)
+	KIND_NODE_IMAGE=kindest/node:v1.29.8@sha256:d46b7aa29567e93b27f7531d258c372e829d7224b25e3fc6ffdefed12476d3aa
+endif
+

--- a/versions.mk
+++ b/versions.mk
@@ -24,8 +24,3 @@ ENVTEST_K8S_VERSION := $(shell echo $(KUBERNETES_VERSION) | cut -d "." -f 1-2)
 # Tools versions which are defined in go.mod
 SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 GINKGO_VERSION := $(shell awk '/github.com\/onsi\/ginkgo\/v2/ {print substr($$2, 2)}' $(SELF_DIR)/go.mod)
-
-ifeq ($(KUBERNETES_VERSION), 1.29.8)
-	KIND_NODE_IMAGE=kindest/node:v1.29.8@sha256:d46b7aa29567e93b27f7531d258c372e829d7224b25e3fc6ffdefed12476d3aa
-endif
-


### PR DESCRIPTION
Not supported due to removal of node image condition in `versions.mk` in https://github.com/topolvm/topolvm/pull/1022